### PR TITLE
Prevent NA strings from being dropped

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ python src/excel_processor.py
 - The output filename includes a timestamp
 - The output file will contain all translations merged by the English text
 
+### Preserving literal values like `None` and `N/A`
+When reading Excel files pandas can treat certain strings as missing values.
+The loader uses `keep_default_na=False` so cells containing strings such as
+`None` or `N/A` remain exactly as typed instead of becoming empty cells.
+
 ## Error Handling
 - The script includes comprehensive error handling and logging
 - Logs are stored in the `logs` directory 

--- a/src/utils.py
+++ b/src/utils.py
@@ -39,7 +39,10 @@ def read_excel_safe(file_path: Path, logger: logging.Logger) -> Optional[pd.Data
     If it fails, log the error and return None.
     """
     try:
-        return pd.read_excel(file_path)
+        # keep_default_na=False prevents strings like "None" or "N/A" from being
+        # interpreted as missing values. This preserves those exact strings in
+        # the DataFrame so they are written back out unchanged.
+        return pd.read_excel(file_path, keep_default_na=False)
     except Exception as e:
         logger.error(f"Error reading file {file_path}: {str(e)}")
         return None


### PR DESCRIPTION
## Summary
- ensure `None`/`N/A` values are not interpreted as missing
- document how NA-like strings are preserved when loading Excel files

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_68530feefb548331948cf0d21a28c6de